### PR TITLE
if we are making a special case for octopus, then lets get it right

### DIFF
--- a/packages/ember-inflector/lib/system/inflections.js
+++ b/packages/ember-inflector/lib/system/inflections.js
@@ -74,7 +74,6 @@ export default {
     'fish',
     'sheep',
     'jeans',
-    'police',
-    'moose'
+    'police'
   ]
 };

--- a/packages/ember-inflector/lib/system/inflections.js
+++ b/packages/ember-inflector/lib/system/inflections.js
@@ -3,8 +3,8 @@ export default {
     [/$/, 's'],
     [/s$/i, 's'],
     [/^(ax|test)is$/i, '$1es'],
-    [/(octop|vir)us$/i, '$1i'],
-    [/(octop|vir)i$/i, '$1i'],
+    [/(vir)us|i$/i, '$1i'],
+    [/(octop)us|odes$/i, '$1odes'],
     [/(alias|status)$/i, '$1es'],
     [/(bu)s$/i, '$1ses'],
     [/(buffal|tomat)o$/i, '$1oes'],
@@ -44,7 +44,8 @@ export default {
     [/(shoe)s$/i, '$1'],
     [/(cris|test)(is|es)$/i, '$1is'],
     [/^(a)x[ie]s$/i, '$1xis'],
-    [/(octop|vir)(us|i)$/i, '$1us'],
+    [/(vir)(us|i)$/i, '$1us'],
+    [/(octop)(us|odes)$/i, '$1us'],
     [/(alias|status)(es)?$/i, '$1'],
     [/^(ox)en/i, '$1'],
     [/(vert|ind)ices$/i, '$1ex'],
@@ -73,6 +74,7 @@ export default {
     'fish',
     'sheep',
     'jeans',
-    'police'
+    'police',
+    'moose'
   ]
 };

--- a/packages/ember-inflector/tests/system/inflector_test.js
+++ b/packages/ember-inflector/tests/system/inflector_test.js
@@ -281,13 +281,15 @@ test('Ember.Inflector.inflector exists', function(){
 });
 
 test('new Ember.Inflector with defaultRules matches docs', function(){
-  expect(4);
+  expect(6);
 
   var inflector = new Ember.Inflector(Ember.Inflector.defaultRules);
 
   // defaultRules includes these special rules
-  equal(inflector.pluralize('cow'), 'kine');
-  equal(inflector.singularize('kine'), 'cow');
+  equal(inflector.pluralize('cow'), 'kine', 'cow -> kine');
+  equal(inflector.singularize('kine'), 'cow',  'kine -> cow');
+  equal(inflector.pluralize('octopus'), 'octopodes', 'octopus -> octopodes');
+  equal(inflector.singularize('octopodes'), 'octopus', 'octopodes -> octopus');
 
   // defaultRules adds 's' to singular
   equal(inflector.pluralize('item'), 'items');

--- a/packages/ember-inflector/tests/system/integration_test.js
+++ b/packages/ember-inflector/tests/system/integration_test.js
@@ -47,7 +47,6 @@ module("ember-inflector.integration - Handlebars Helpers", {
 
       appendView(view);
       text = $("#qunit-fixture").text();
-      console.log(text);
     });
   },
 

--- a/packages/ember-inflector/tests/system/integration_test.js
+++ b/packages/ember-inflector/tests/system/integration_test.js
@@ -13,7 +13,7 @@ test("pluralize", function(){
 
   equal(Ember.String.pluralize('word'),     'words');
   equal(Ember.String.pluralize('ox'),       'oxen');
-  equal(Ember.String.pluralize('octopus'),  'octopi');
+  equal(Ember.String.pluralize('octopus'),  'octopodes');
 });
 
 test("singularize", function(){
@@ -21,7 +21,7 @@ test("singularize", function(){
 
   equal(Ember.String.singularize('words'),  'word');
   equal(Ember.String.singularize('oxen'),   'ox');
-  equal(Ember.String.singularize('octopi'), 'octopus');
+  equal(Ember.String.singularize('octopodes'), 'octopus');
 });
 
 module("ember-inflector.integration - Handlebars Helpers", {
@@ -32,7 +32,7 @@ module("ember-inflector.integration - Handlebars Helpers", {
       view = Ember.View.create({
         template: Ember.Handlebars.compile("{{singularize plural}} {{pluralize single}} {{pluralize 1 singleArg}} {{pluralize 2 multiple}} {{pluralize one boundSingle}} {{pluralize oneString boundSingleString}} {{pluralize two boundMultiple}}"),
         context: {
-          plural: "octopi",
+          plural: "octopodes",
           single: "ox",
           singleArg: "opossums",
           multiple: "ocelot",
@@ -47,6 +47,7 @@ module("ember-inflector.integration - Handlebars Helpers", {
 
       appendView(view);
       text = $("#qunit-fixture").text();
+      console.log(text);
     });
   },
 


### PR DESCRIPTION
I will also happily modify this to just do octopuses (also added moose to uncountable, but resisted urge to change [/^([v|b]ox|ox)en/i, '$1'])