### PR TITLE
fix package.json main

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "keywords": [
     "ember-addon"
   ],
-  "main": "lib/ember-addon/index.js",
+  "main": "addon/index.js",
   "ember-addon": {
     "configPath": "tests/dummy/config"
   }


### PR DESCRIPTION
now it should be `addon/index.js` or we remove the main property because we have the `index.js`:
> This is generally caused by an addon not having a `main` entry point (or `index.js`).

