### PR TITLE
Add the Repository field to Package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "build": "ember build",
     "test": "ember test"
   },
-  "repository": "",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/stefanpenner/ember-inflector.git"  
+  },
   "engines": {
     "node": ">= 0.10.0"
   },


### PR DESCRIPTION
Just want to get rid of this little error message:
npm WARN package.json ember-inflector@1.6.0 No repository field.