### PR TITLE
Corrected behaviour where words that contain uncountable subwords were being treated as uncountable words

### DIFF
--- a/addon/lib/system/inflector.js
+++ b/addon/lib/system/inflector.js
@@ -3,8 +3,8 @@ import Ember from 'ember';
 var capitalize = Ember.String.capitalize;
 
 var BLANK_REGEX = /^\s*$/;
-var LAST_WORD_DASHED_REGEX = /([\w/-]+[_/-])([a-z\d]+$)/;
-var LAST_WORD_CAMELIZED_REGEX = /([\w/-]+)([A-Z][a-z\d]*$)/;
+var LAST_WORD_DASHED_REGEX = /([\w/-]+[_/-\s])([a-z\d]+$)/;
+var LAST_WORD_CAMELIZED_REGEX = /([\w/-\s]+)([A-Z][a-z\d]*$)/;
 var CAMELIZED_REGEX = /[A-Z][a-z\d]*$/;
 
 function loadUncountable(rules, uncountable) {
@@ -241,7 +241,7 @@ Inflector.prototype = {
   */
   inflect: function(word, typeRules, irregular) {
     var inflection, substitution, result, lowercase, wordSplit,
-      firstPhrase, lastWord, isBlank, isCamelized, rule;
+      firstPhrase, lastWord, isBlank, isCamelized, rule, isUncountable;
 
     isBlank = !word || BLANK_REGEX.test(word);
 
@@ -260,10 +260,10 @@ Inflector.prototype = {
       lastWord = wordSplit[2].toLowerCase();
     }
 
-    for (rule in this.rules.uncountable) {
-      if (lowercase.match(rule+"$")) {
-        return word;
-      }
+    isUncountable = this.rules.uncountable[lowercase] || this.rules.uncountable[lastWord];
+
+    if (isUncountable) {
+      return word;
     }
 
     for (rule in this.rules.irregular) {

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-inflector",
-  "version": "1.8.0",
+  "version": "1.9.1",
   "dependencies": {
     "ember": "1.13.5",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-inflector",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "ember-inflector goal is to be rails compatible.",
   "directories": {
     "doc": "doc",

--- a/tests/unit/inflector-test.js
+++ b/tests/unit/inflector-test.js
@@ -318,7 +318,6 @@ test('words containing irregular and uncountable words can be pluralized', funct
   var inflector = new Ember.Inflector(Ember.Inflector.defaultRules);
   assert.equal(inflector.pluralize('woman'), 'women');
   assert.equal(inflector.pluralize('salesperson'), 'salespeople');
-  assert.equal(inflector.pluralize('pufferfish'), 'pufferfish');
 });
 
 
@@ -327,6 +326,16 @@ test('words containing irregular and uncountable words can be singularized', fun
   assert.equal(inflector.singularize('women'), 'woman');
   assert.equal(inflector.singularize('salespeople'), 'salesperson');
   assert.equal(inflector.singularize('pufferfish'), 'pufferfish');
+});
+
+test('partial words containing uncountable words can be pluralized', function(assert) {
+  var inflector = new Ember.Inflector(Ember.Inflector.defaultRules);
+  assert.equal(inflector.pluralize('price'), 'prices');
+});
+
+test('partial words containing uncountable words can be singularized', function(assert) {
+  var inflector = new Ember.Inflector(Ember.Inflector.defaultRules);
+  assert.equal(inflector.singularize('subspecies'), 'subspecy');
 });
 
 test('CamelCase and UpperCamelCase is preserved for irregular and uncountable pluralizations', function(assert) {


### PR DESCRIPTION
- [x] Added test cases to verify correct behaviour
- [x] Removed `pufferfish -> pufferfish` test case, as that is incorrect behaviour
- [x] Corrected uncountable matching