### PR TITLE
Fixed regex that resulted in an invalid range in older browsers

### DIFF
--- a/addon/lib/system/inflector.js
+++ b/addon/lib/system/inflector.js
@@ -3,8 +3,8 @@ import Ember from 'ember';
 var capitalize = Ember.String.capitalize;
 
 var BLANK_REGEX = /^\s*$/;
-var LAST_WORD_DASHED_REGEX = /([\w/-]+[_/-\s])([a-z\d]+$)/;
-var LAST_WORD_CAMELIZED_REGEX = /([\w/-\s]+)([A-Z][a-z\d]*$)/;
+var LAST_WORD_DASHED_REGEX = /([\w/-]+[_/\s-])([a-z\d]+$)/;
+var LAST_WORD_CAMELIZED_REGEX = /([\w/\s-]+)([A-Z][a-z\d]*$)/;
 var CAMELIZED_REGEX = /[A-Z][a-z\d]*$/;
 
 function loadUncountable(rules, uncountable) {


### PR DESCRIPTION
The regex `[_/-\s]` will cause error "Invalid range in character set" because it creates a range between the `/` and the `\s` characters. The hyphen needs to be escaped or moved to the end. Problem was observed in IE8, Firefox 14, and 24.

Related: http://stackoverflow.com/questions/23496973/invalid-range-in-character-class-regex-firefox