### PR TITLE
[bugfix release] fix using helpers without default Inflector

### DIFF
--- a/addon/lib/helpers/pluralize.js
+++ b/addon/lib/helpers/pluralize.js
@@ -1,4 +1,4 @@
-import { pluralize } from '../system/string';
+import { pluralize } from 'ember-inflector';
 import makeHelper from '../utils/make-helper';
 
 /**

--- a/addon/lib/helpers/singularize.js
+++ b/addon/lib/helpers/singularize.js
@@ -1,4 +1,4 @@
-import { singularize } from '../system/string';
+import { singularize } from 'ember-inflector';
 import makeHelper from '../utils/make-helper';
 
 /**


### PR DESCRIPTION
The singularize and pluralize helpers previously imported the
helpers previously without a default Ember Inflector instance,
which would cause issues for Ember CLI users.

refs GH-74