### PR TITLE
Correctly pluralize floats between 1 and 2

### DIFF
--- a/addon/lib/helpers/pluralize.js
+++ b/addon/lib/helpers/pluralize.js
@@ -19,7 +19,7 @@ import makeHelper from '../utils/make-helper';
  * @param {String|Property} word word to pluralize
 */
 export default makeHelper(function (params) {
-  var count, word;
+  let count, word;
 
   if (params.length === 1) {
     word = params[0];
@@ -28,9 +28,10 @@ export default makeHelper(function (params) {
     count = params[0];
     word  = params[1];
 
-    if ((count | 0) !== 1) {
+    if (parseFloat(count) !== 1) {
       word = pluralize(word);
     }
+
     return count + " " + word;
   }
 });

--- a/tests/unit/inflector-test.js
+++ b/tests/unit/inflector-test.js
@@ -540,4 +540,3 @@ test('Ember.Inflector.singularize passes same test cases as ActiveSupport::Infle
   assert.equal(inflector.singularize('slices'), 'slice');
   assert.equal(inflector.singularize('police'), 'police');
 });
-

--- a/tests/unit/integration-test.js
+++ b/tests/unit/integration-test.js
@@ -56,11 +56,32 @@ test("helpers - pluralize - bound count 1", function(assert) {
   assert.equal(this.$().text(), '1 orange');
 });
 
+test("helpers - pluralize - bound count 1.0 float", function(assert) {
+  this.set('count', 1.0);
+  this.set('singular', 'owl');
+  this.render('{{pluralize count singular}}');
+  assert.equal(this.$().text(), '1 owl');
+});
+
+test("helpers - pluralize - bound count 1.5 float", function(assert) {
+  this.set('count', 1.5);
+  this.set('singular', 'owl');
+  this.render('{{pluralize count singular}}');
+  assert.equal(this.$().text(), '1.5 owls');
+});
+
 test("helpers - pluralize - bound count 1.0 string", function(assert) {
   this.set('count', '1.0');
   this.set('singular', 'owl');
   this.render('{{pluralize count singular}}');
   assert.equal(this.$().text(), '1.0 owl');
+});
+
+test("helpers - pluralize - bound count 1.5 string", function(assert) {
+  this.set('count', '1.5');
+  this.set('singular', 'owl');
+  this.render('{{pluralize count singular}}');
+  assert.equal(this.$().text(), '1.5 owls');
 });
 
 test("helpers - pluralize - bound count 2", function(assert) {


### PR DESCRIPTION
This fixes https://github.com/stefanpenner/ember-inflector/issues/94

It also adds some test additional test cases to document the current
behavior.

One additional strange bit is that the float 1.0 is returned as 1 when
concatenated into the string. I'm not sure if this is the ideal response
but I did not see any clear way to handle keeping that as 1.0 in the
returned string. This is the current behavior so changing it might
cause some unintended side-effects.

/shrug javascripts